### PR TITLE
Feat: Add deployment, service and replica sets yaml files

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -4,8 +4,8 @@ WORKDIR /app
 
 COPY ./package*.json /app/
 
-RUN npm install --only=prod
+RUN yarn install
 
 COPY . .
 
-CMD [ "npm", "start" ]
+CMD [ "yarn", "dev" ]

--- a/k8s/tickets-api-deploy.yaml
+++ b/k8s/tickets-api-deploy.yaml
@@ -1,0 +1,71 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tickets-api-deploy
+  namespace: default
+  labels:
+    app: tickets-api-deploy
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  minReadySeconds: 5
+  selector:
+    matchLabels:
+      app: tickets-api
+      tier: api
+
+  template:
+    metadata:
+      name: tickets-api-pod
+      labels:
+        app: tickets-api
+        tier: api
+    spec:
+      containers:
+        - name: tickets-api-container
+          image: olavokruel/tickets-api
+          ports:
+            - containerPort: 3000
+          resources:
+            requests:
+              cpu: 200m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 1280Mi
+          env:
+            - name: NATS_CLUSTER_ID
+              value: 'ecommerce'
+            - name: NATS_CLIENT_ID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: NATS_URL
+              value: 'http://nat-stream-server-svc:4222'
+            - name: MONGO_URI
+              value: 'mongodb://tickets-mongo-db-svc:27017/tickets'
+            - name: JWT_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: auth-secrets
+                  key: jwt
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: tickets-api-svc
+  namespace: default
+spec:
+  type: ClusterIP
+  selector:
+    app: tickets-api
+    tier: api
+  ports:
+    - name: tickets-api-ports
+      protocol: TCP
+      targetPort: 3000
+      port: 3000

--- a/k8s/tickets-mongo-db-deploy.yaml
+++ b/k8s/tickets-mongo-db-deploy.yaml
@@ -1,0 +1,64 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name:  tickets-mongo-db-deploy
+  namespace: default
+  labels:
+    app:  tickets-mongodb-db-deploy
+spec:
+  replicas: 1
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  minReadySeconds: 5
+  selector:
+    matchLabels:
+      app: tickets-mongo-db
+      tier: database
+
+  template:
+    metadata:
+      name: tickets-mongo-db-pod
+      labels:
+        app: tickets-mongo-db
+        tier: database
+    spec:
+      containers:
+        - name:  tickets-mongo-db-container
+          image:  mongo
+          ports:
+            - containerPort:  27017
+          resources:
+      #       requests:
+      #         cpu: "0.25"
+      #         memory: '500Mi'
+      #       limits:
+      #         cpu: "0.25"
+      #         memory: '600Mi'
+      #     env:
+      #     - name: DB_HOST
+      #     volumeMounts:
+      #     - name: localtime
+      #       mountPath: /etc/localtime
+      # volumes:
+      #   - name: localtime
+      #     hostPath:
+      #       path: /usr/share/zoneinfo/Asia/Shanghai
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: tickets-mongo-db-svc
+  namespace: default
+spec:
+  type: ClusterIP
+  selector:
+    app: tickets-mongo-db
+    tier: database
+  ports:
+    - name: tickets-mongo-db-ports
+      protocol: TCP
+      targetPort: 27017
+      port: 27017


### PR DESCRIPTION
Closes #1 

Add deployment, service and replica sets yaml files for Ticket API and Mongo DB

Working locally in minikube with auth-ui, auth-api, nats-server, nginx projects

Github issue: https://github.com/OKruel/tickets-api/issues/1